### PR TITLE
fixed p a r e n t h e t i c a l bug

### DIFF
--- a/screenplain/export/html.py
+++ b/screenplain/export/html.py
@@ -115,7 +115,7 @@ class Formatter(object):
             self.out.write(to_html(dialog.character))
 
         for parenthetical, text in dialog.blocks:
-            classes = 'parenthetical' if parenthetical else None
+            classes = ['parenthetical'] if parenthetical else None
             with self._tag('p', classes=classes):
                 self.out.write(to_html(text))
 


### PR DESCRIPTION
Fixes a bug that caused the class of parenthetical elements in the dialogue to be rendered as <p class="p a r e n t h e t i c a l">.

The value of the class variable is supposed to be iterable, e.g. a list. Making it a string, caused the following functions to join every character of the string seperated by a blank.

Fixed by turning the value of the class variable into a list with one element.
