### PR TITLE
Right align transitions in PDF output

### DIFF
--- a/screenplain/export/pdf.py
+++ b/screenplain/export/pdf.py
@@ -22,7 +22,7 @@ from reportlab.platypus import (
 from reportlab import platypus
 from reportlab.lib.units import inch
 from reportlab.lib.styles import ParagraphStyle
-from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.enums import TA_CENTER, TA_RIGHT
 
 from screenplain.types import (
     Action, Dialog, DualDialog, Transition, Slug
@@ -91,6 +91,7 @@ transition_style = ParagraphStyle(
     'transition', default_style,
     spaceBefore=12,
     spaceAfter=12,
+    alignment=TA_RIGHT,
 )
 
 # Title page styles


### PR DESCRIPTION
I'm not certain but I think transitions like `CUT TO:` are supposed to be right aligned. Thank you for writing this program, it's excellent.