### PR TITLE
PDF page break threshold for Slugs & Character Names

### DIFF
--- a/tests/files/awkward-page-breaks.fountain
+++ b/tests/files/awkward-page-breaks.fountain
@@ -1,0 +1,58 @@
+INT. SOMEWHERE - DAY
+
+Stuff happens.
+
+So much stuff happens, that this scene takes up exactly one page.
+
+And when we export this as a PDF with 55 "lines per page" and 61 "characters per line" (unless we protect against it) the next scene heading will end up being orphaned at the bottom of this page, with nothing below it. The contents of the next scene will appear on the following page, without any heading.
+
+ALPHA
+Bravo.
+
+CHARLIE
+Delta.
+
+ECHO
+Foxtrot.
+
+GOLF
+Hotel.
+
+INDIA
+Juliet.
+
+KILO
+Lima.
+
+MIKE
+November.
+
+OSCAR
+Papa.
+
+QUEBEC
+Romeo.
+
+SIERRA
+Tango.
+
+UMBRELLA
+Victor.
+
+Whiskey X-ray. Yankee Zulu. Whiskey X-ray. Yankee Zulu.Whiskey X-ray. Yankee Zulu.Whiskey X-ray. Yankee Zulu.Whiskey X-ray. Yankee Zulu.Whiskey X-ray. 
+
+INT. SOMEWHERE ELSE, TO BE CERTAIN - NIGHT
+
+Exported as a PDF with 55 "lines per page" and 61 "characters per line", this scene will appear at the top of a page, with no heading above it.
+
+ALPHA
+Bravo.
+
+CHARLIE
+Delta.
+
+ECHO
+Foxtrot.
+
+GOLF
+Hotel.

--- a/tests/pdf_test.py
+++ b/tests/pdf_test.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2011 Martin Vilcans
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license.php
+
+from testcompat import TestCase
+from StringIO import StringIO
+
+from screenplain.export.pdf import to_pdf
+from screenplain.richstring import plain, bold, italic
+
+
+class OutputTests(TestCase):
+
+    def setUp(self):
+        self.out = StringIO()
+        # TODO: figure out how to test PDF export
+
+    def test_scene_heading_page_break_threshold(self):
+        self.assertEqual(1, 1)
+        # TODO: test PDF export should not break heading from scene
+
+    def test_character_name_page_break_threshold(self):
+        self.assertEqual(1, 1)
+        # TODO: test PDF export should not break character name from dialog


### PR DESCRIPTION
Close #13 PDF page break threshold for Slugs & Character Names 

Open #15 Tests for ReportLab PDF output