### PR TITLE
PDF exports Scene Headings as Bold and Underlined

### DIFF
--- a/screenplain/export/pdf.py
+++ b/screenplain/export/pdf.py
@@ -142,6 +142,11 @@ def add_paragraph(story, para, style):
         story.append(Paragraph(line.to_html(), style))
 
 
+def add_slug(story, para, style):
+    for line in para.lines:
+        story.append(Paragraph('<b><u>' + line.to_html() + '</u></b>', style))
+
+
 def add_dialog(story, dialog):
     story.append(Paragraph(dialog.character.to_html(), character_style))
     for parenthetical, line in dialog.blocks:
@@ -236,7 +241,7 @@ def to_pdf(screenplay, output_filename, template_constructor=DocTemplate):
                 centered_action_style if para.centered else action_style
             )
         elif isinstance(para, Slug):
-            add_paragraph(story, para, slug_style)
+            add_slug(story, para, slug_style)
         elif isinstance(para, Transition):
             add_paragraph(story, para, transition_style)
         elif isinstance(para, types.PageBreak):

--- a/tests/pdf_test.py
+++ b/tests/pdf_test.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2011 Martin Vilcans
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license.php
+
+from testcompat import TestCase
+from StringIO import StringIO
+
+from screenplain.export.pdf import to_pdf
+from screenplain.richstring import plain, bold, italic
+
+
+class OutputTests(TestCase):
+
+    def setUp(self):
+        self.out = StringIO()
+        # TODO: figure out how to test PDF export
+
+    def test_scene_heading_bold_underlined(self):
+        self.assertEqual(1, 1)
+        # TODO: test PDF exports Scene Headings as Bold and Underlined


### PR DESCRIPTION
Close #14 PDF exports Scene Headings as Bold and Underlined

Relates to #15 Reports for PDF Output