### PR TITLE
Ignore lib directory when checking code style

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/bash
 nosetests --nocapture --with-doctest --doctest-tests $* && \
-  pep8 --ignore=E402 screenplain tests
+  pep8 --ignore=E402 --exclude=screenplain/lib/ screenplain tests


### PR DESCRIPTION
When using virtualenv to prepare developer mode, `screenplain/lib` is full of python files that should not be checked.