### PR TITLE
Minor py2/py3 compatibility change for generator.next fn

### DIFF
--- a/screenplain/parsers/fountain.py
+++ b/screenplain/parsers/fountain.py
@@ -5,6 +5,7 @@
 import itertools
 from itertools import takewhile
 import re
+import six
 
 from screenplain.types import (
     Slug, Action, Dialog, DualDialog, Transition, Section, PageBreak,
@@ -269,7 +270,7 @@ def parse_title_page(lines):
 
     it = iter(lines)
     try:
-        line = it.next()
+        line = six.next(it)
         while True:
             key_match = title_page_key_re.match(line)
             if not key_match:


### PR DESCRIPTION
`python2` uses the syntax `generator.next()` whereas `python3` updates this same method to `generator.__next__()`. This P/R uses the `six` library's `next()` function for py2 + py3 compatibility.
