### PR TITLE
py2/py3 - always use string object in re.sub

### DIFF
--- a/screenplain/richstring.py
+++ b/screenplain/richstring.py
@@ -116,7 +116,7 @@ class Segment(object):
             re.sub(
                 '  +',  # at least two spaces
                 lambda m: '&nbsp;' * (len(m.group(0)) - 1) + ' ',
-                cgi.escape(self.text).encode('ascii', 'xmlcharrefreplace'),
+                cgi.escape(self.text).encode('utf-8', 'xmlcharrefreplace').decode('utf-8'),
             ) +
             ''.join(style.end_html for style in reversed(ordered_styles))
         )


### PR DESCRIPTION
Needs to be tested on actual python2 project/environment for compatibility.

Python3 returns a `bytes` object which `re.sub` cries about. I also was not sure if there was reason for usage of `ascii` encoding so I switched to `utf-8`.