### PR TITLE
export/pdf: use left aligned contact information.

### DIFF
--- a/screenplain/export/pdf.py
+++ b/screenplain/export/pdf.py
@@ -105,8 +105,6 @@ title_style = ParagraphStyle(
 )
 contact_style = ParagraphStyle(
     'contact', default_style,
-    leftIndent=3.9 * inch,
-    rightIndent=0,
 )
 
 


### PR DESCRIPTION
Closes #48.

See also #40.