### PR TITLE
Fix Python 3/3.8 compatibility

### DIFF
--- a/screenplain/main.py
+++ b/screenplain/main.py
@@ -109,9 +109,9 @@ def main(args):
             output = open(output_file, 'wb')
     else:
         if output_encoding:
-            output = codecs.getwriter(output_encoding)(sys.stdout)
+            output = codecs.getwriter(output_encoding)(sys.stdout.buffer)
         else:
-            output = sys.stdout
+            output = sys.stdout.buffer
 
     try:
         if format == 'text':

--- a/screenplain/richstring.py
+++ b/screenplain/richstring.py
@@ -3,8 +3,12 @@
 # http://www.opensource.org/licenses/mit-license.php
 
 import re
-import cgi
 import six
+
+try:
+    from html import escape as html_escape
+except ImportError:
+    from cgi import escape as html_escape
 
 _magic_re = re.compile(u'[\ue700-\ue705]')
 
@@ -14,7 +18,7 @@ def _escape(s):
     and non-ascii characters with ampersand escapes.
 
     """
-    encoded = cgi.escape(s).encode('ascii', 'xmlcharrefreplace')
+    encoded = html_escape(s, quote=False).encode('ascii', 'xmlcharrefreplace')
     # In Py3, encoded is bytes type, so convert it to a string
     return encoded.decode('ascii')
 


### PR DESCRIPTION

Full error:

    % screenplain Big-Fish.fountain Big-Fish.html
    Traceback (most recent call last):
      File "/Users/user/.ve38/bin/screenplain", line 6, in <module>
        main(sys.argv[1:])
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/main.py", line 125, in main
        convert(
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 183, in convert
        convert_full(
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 210, in convert_full
        convert_bare(screenplay, out)
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 225, in convert_bare
        formatter.convert(screenplay)
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 99, in convert
        format_function(para)
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 153, in format_action
        self.out.write(to_html(line))
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/export/html.py", line 60, in to_html
        html = text.to_html()
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/richstring.py", line 62, in to_html
        html = ''.join(seg.to_html() for seg in self.segments)
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/richstring.py", line 62, in <genexpr>
        html = ''.join(seg.to_html() for seg in self.segments)
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/richstring.py", line 136, in to_html
        _escape(self.text),
      File "/Users/user/.ve38/lib/python3.8/site-packages/screenplain/richstring.py", line 17, in _escape
        encoded = cgi.escape(s).encode('ascii', 'xmlcharrefreplace')
    AttributeError: module 'cgi' has no attribute 'escape'

cgi.escape() is gone in Python 3.8, html.escape() should be used
instead. Since html.escape() defaults to quote=True, we need to
explicitly disable escaping quotation marks to keep doing the same
thing. A question arises though – should quotation marks be actually
kept verbatim here or was it unintentional?