### PR TITLE
Add Windows support

### DIFF
--- a/bin/screenplain
+++ b/bin/screenplain
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-import sys
-
-if __name__ == '__main__':
-   from screenplain.main import main
-   main(sys.argv[1:])

--- a/bin/test.bat
+++ b/bin/test.bat
@@ -1,0 +1,2 @@
+nosetests --nocapture --with-doctest --doctest-tests
+pycodestyle --ignore=E402,W504 screenplain tests

--- a/screenplain/main.py
+++ b/screenplain/main.py
@@ -134,5 +134,10 @@ def main(args):
             output.close()
 
 
+def cli():
+    """setup.py entry point for console scripts."""
+    main(sys.argv[1:])
+
+
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,11 @@ setup(
     package_data={
         'screenplain.export': ['default.css']
     },
-    scripts=[
-        'bin/screenplain'
-    ],
+    entry_points={
+        'console_scripts': [
+            'screenplain = screenplain.main:cli'
+        ]
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Use `setuptools`' `entry_points` to generate the command line script.  This small change allows screenplain to run on Windows.

I understand if the project doesn't want to officially support Windows, but this change should not affect POSIX systems.