### PR TITLE
Cleanup testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 python:
+  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
 install: pip install -r requirements.txt
-script: bin/test
+script:
+    - python -munittest discover -v -p '*test*.py'
+    - python -mdoctest -v screenplain/*.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE.txt
+recursive-include tests *

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-nosetests --nocapture --with-doctest --doctest-tests
-pycodestyle --ignore=E402,W504 screenplain tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 reportlab
-unittest2
-nose
 pycodestyle

--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+python3 -munittest discover -v -p '*test*.py'
+python3 -mdoctest -v screenplain/*.py
+
+pycodestyle --ignore=E402,W504 screenplain tests

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@
 from setuptools import setup
 
 # read the contents of your README file
-from os import path
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+import os.path
+import io
+
+this_directory = os.path.abspath(os.path.dirname(__file__))
+with io.open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(

--- a/tests/fdx_test.py
+++ b/tests/fdx_test.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license.php
 
-from testcompat import TestCase
+from .testcompat import TestCase
 from io import StringIO
 
 from screenplain.export.fdx import write_text

--- a/tests/files_test.py
+++ b/tests/files_test.py
@@ -4,7 +4,7 @@
 
 from __future__ import with_statement
 
-from testcompat import TestCase
+from .testcompat import TestCase
 import tempfile
 import os
 import os.path

--- a/tests/fountain_test.py
+++ b/tests/fountain_test.py
@@ -24,7 +24,7 @@ class SlugTests(TestCase):
             '',
             'THIS IS JUST ACTION',
         ])
-        self.assertEquals([Slug, Action], [type(p) for p in paras])
+        self.assertEqual([Slug, Action], [type(p) for p in paras])
 
     def test_slug_must_be_single_line(self):
         paras = parse([
@@ -33,18 +33,18 @@ class SlugTests(TestCase):
             '',
             'Some action',
         ])
-        self.assertEquals([Dialog, Action], [type(p) for p in paras])
+        self.assertEqual([Dialog, Action], [type(p) for p in paras])
         # What looks like a scene headingis parsed as a character name.
         # Unexpected perhaps, but that's how I interpreted the spec.
-        self.assertEquals(plain('INT. SOMEWHERE - DAY'), paras[0].character)
-        self.assertEquals([plain('Some action')], paras[1].lines)
+        self.assertEqual(plain('INT. SOMEWHERE - DAY'), paras[0].character)
+        self.assertEqual([plain('Some action')], paras[1].lines)
 
     def test_action_is_not_a_slug(self):
         paras = parse([
             '',
             'THIS IS JUST ACTION',
         ])
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
 
     def test_two_lines_creates_no_slug(self):
         types = [type(p) for p in parse([
@@ -54,40 +54,40 @@ class SlugTests(TestCase):
             '',
         ])]
         # This used to be Slug. Changed in the Jan 2012 version of the spec.
-        self.assertEquals([Action], types)
+        self.assertEqual([Action], types)
 
     def test_period_creates_slug(self):
         paras = parse([
             '.SNIPER SCOPE POV',
             '',
         ])
-        self.assertEquals(1, len(paras))
-        self.assertEquals(Slug, type(paras[0]))
-        self.assertEquals(plain('SNIPER SCOPE POV'), paras[0].line)
+        self.assertEqual(1, len(paras))
+        self.assertEqual(Slug, type(paras[0]))
+        self.assertEqual(plain('SNIPER SCOPE POV'), paras[0].line)
 
     def test_more_than_one_period_does_not_create_slug(self):
         paras = parse([
             '..AND THEN...',
             '',
         ])
-        self.assertEquals(1, len(paras))
-        self.assertEquals(Action, type(paras[0]))
-        self.assertEquals(plain('..AND THEN...'), paras[0].lines[0])
+        self.assertEqual(1, len(paras))
+        self.assertEqual(Action, type(paras[0]))
+        self.assertEqual(plain('..AND THEN...'), paras[0].lines[0])
 
     def test_scene_number_is_parsed(self):
         paras = parse(['EXT SOMEWHERE - DAY #42#'])
-        self.assertEquals(plain('EXT SOMEWHERE - DAY'), paras[0].line)
-        self.assertEquals(plain('42'), paras[0].scene_number)
+        self.assertEqual(plain('EXT SOMEWHERE - DAY'), paras[0].line)
+        self.assertEqual(plain('42'), paras[0].scene_number)
 
     def test_only_last_two_hashes_in_slug_used_for_scene_number(self):
         paras = parse(['INT ROOM #237 #42#'])
-        self.assertEquals(plain('42'), paras[0].scene_number)
-        self.assertEquals(plain('INT ROOM #237'), paras[0].line)
+        self.assertEqual(plain('42'), paras[0].scene_number)
+        self.assertEqual(plain('INT ROOM #237'), paras[0].line)
 
     def test_scene_number_must_be_alphanumeric(self):
         paras = parse(['.SOMEWHERE #*HELLO*#'])
         self.assertIsNone(paras[0].scene_number)
-        self.assertEquals(
+        self.assertEqual(
             (plain)(u'SOMEWHERE #') + (italic)(u'HELLO') + (plain)(u'#'),
             paras[0].line
         )
@@ -100,11 +100,11 @@ class SectionTests(TestCase):
             '',
             '## second level',
         ])
-        self.assertEquals([Section, Section], [type(p) for p in paras])
-        self.assertEquals(1, paras[0].level)
-        self.assertEquals(plain('first level'), paras[0].text)
-        self.assertEquals(2, paras[1].level)
-        self.assertEquals(plain('second level'), paras[1].text)
+        self.assertEqual([Section, Section], [type(p) for p in paras])
+        self.assertEqual(1, paras[0].level)
+        self.assertEqual(plain('first level'), paras[0].text)
+        self.assertEqual(2, paras[1].level)
+        self.assertEqual(plain('second level'), paras[1].text)
 
     def test_multiple_sections_in_one_paragraph(self):
         paras = parse([
@@ -112,16 +112,16 @@ class SectionTests(TestCase):
             '## second level',
             '# first level again'
         ])
-        self.assertEquals(
+        self.assertEqual(
             [Section, Section, Section],
             [type(p) for p in paras]
         )
-        self.assertEquals(1, paras[0].level)
-        self.assertEquals(plain('first level'), paras[0].text)
-        self.assertEquals(2, paras[1].level)
-        self.assertEquals(plain('second level'), paras[1].text)
-        self.assertEquals(1, paras[2].level)
-        self.assertEquals(plain('first level again'), paras[2].text)
+        self.assertEqual(1, paras[0].level)
+        self.assertEqual(plain('first level'), paras[0].text)
+        self.assertEqual(2, paras[1].level)
+        self.assertEqual(plain('second level'), paras[1].text)
+        self.assertEqual(1, paras[2].level)
+        self.assertEqual(plain('first level again'), paras[2].text)
 
     def test_multiple_sections_with_synopsis(self):
         paras = parse([
@@ -129,7 +129,7 @@ class SectionTests(TestCase):
             '= level one synopsis',
             '## second level',
         ])
-        self.assertEquals([
+        self.assertEqual([
             Section(plain(u'first level'), 1, 'level one synopsis'),
             Section(plain(u'second level'), 2, None),
         ], paras)
@@ -143,18 +143,18 @@ class DialogTests(TestCase):
             'SOME GUY',
             'Hello',
         ])]
-        self.assertEquals(1, len(paras))
+        self.assertEqual(1, len(paras))
         dialog = paras[0]
-        self.assertEquals(Dialog, type(dialog))
-        self.assertEquals(plain('SOME GUY'), dialog.character)
+        self.assertEqual(Dialog, type(dialog))
+        self.assertEqual(plain('SOME GUY'), dialog.character)
 
     def test_alphanumeric_character(self):
         paras = parse([
             'R2D2',
             'Bee-bop',
         ])
-        self.assertEquals([Dialog], [type(p) for p in paras])
-        self.assertEquals(plain('R2D2'), paras[0].character)
+        self.assertEqual([Dialog], [type(p) for p in paras])
+        self.assertEqual(plain('R2D2'), paras[0].character)
 
     # Spec http://fountain.io/syntax#section-character:
     # Character names must include at least one alphabetical character.
@@ -164,7 +164,7 @@ class DialogTests(TestCase):
             '23',
             'Hello',
         ])
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
 
     # Spec http://fountain.io/syntax#section-character:
     # You can force a Character element by preceding it with the "at" symbol @.
@@ -173,15 +173,15 @@ class DialogTests(TestCase):
             '@McCLANE',
             'Yippee ki-yay',
         ])
-        self.assertEquals([Dialog], [type(p) for p in paras])
-        self.assertEquals(plain('McCLANE'), paras[0].character)
+        self.assertEqual([Dialog], [type(p) for p in paras])
+        self.assertEqual(plain('McCLANE'), paras[0].character)
 
     def test_twospaced_line_is_not_character(self):
         paras = parse([
             'SCANNING THE AISLES...  ',
             'Where is that pit boss?',
         ])
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
 
     def test_simple_parenthetical(self):
         paras = parse([
@@ -189,7 +189,7 @@ class DialogTests(TestCase):
             '(starting the engine)',
             'So much for retirement!',
         ])
-        self.assertEquals(1, len(paras))
+        self.assertEqual(1, len(paras))
         dialog = paras[0]
         self.assertEqual(2, len(dialog.blocks))
         self.assertEqual(
@@ -208,8 +208,8 @@ class DialogTests(TestCase):
             '  ',
             'Two',
         ])
-        self.assertEquals([Dialog], [type(p) for p in paras])
-        self.assertEquals([
+        self.assertEqual([Dialog], [type(p) for p in paras])
+        self.assertEqual([
             (False, plain('One')),
             (False, empty_string),
             (False, plain('Two')),
@@ -223,15 +223,15 @@ class DialogTests(TestCase):
             'STEEL ^',
             'Fuck retirement!',
         ])
-        self.assertEquals([DualDialog], [type(p) for p in paras])
+        self.assertEqual([DualDialog], [type(p) for p in paras])
         dual = paras[0]
-        self.assertEquals(plain('BRICK'), dual.left.character)
-        self.assertEquals(
+        self.assertEqual(plain('BRICK'), dual.left.character)
+        self.assertEqual(
             [(False, plain('Fuck retirement.'))],
             dual.left.blocks
         )
-        self.assertEquals(plain('STEEL'), dual.right.character)
-        self.assertEquals(
+        self.assertEqual(plain('STEEL'), dual.right.character)
+        self.assertEqual(
             [(False, plain('Fuck retirement!'))],
             dual.right.blocks
         )
@@ -243,7 +243,7 @@ class DialogTests(TestCase):
             'BRICK ^',
             'Nice retirement.',
         ])
-        self.assertEquals([Action, Dialog], [type(p) for p in paras])
+        self.assertEqual([Action, Dialog], [type(p) for p in paras])
         dialog = paras[1]
         self.assertEqual(plain('BRICK ^'), dialog.character)
         self.assertEqual([
@@ -258,8 +258,8 @@ class DialogTests(TestCase):
             'Or, if thou wilt not, be but sworn my love,',
             " And I'll no longer be a Capulet.",
         ])
-        self.assertEquals([Dialog], [type(p) for p in paras])
-        self.assertEquals([
+        self.assertEqual([Dialog], [type(p) for p in paras])
+        self.assertEqual([
             (False, plain(u'O Romeo, Romeo! wherefore art thou Romeo?')),
             (False, plain(u'Deny thy father and refuse thy name;')),
             (False, plain(u'Or, if thou wilt not, be but sworn my love,')),
@@ -277,7 +277,7 @@ class TransitionTests(TestCase):
             '',
             "EXT. BRICK'S POOL - DAY",
         ])
-        self.assertEquals([Action, Transition, Slug], [type(p) for p in paras])
+        self.assertEqual([Action, Transition, Slug], [type(p) for p in paras])
 
     def test_transition_must_end_with_to(self):
         paras = parse([
@@ -285,7 +285,7 @@ class TransitionTests(TestCase):
             '',
             "EXT. BRICK'S POOL - DAY",
         ])
-        self.assertEquals([Action, Slug], [type(p) for p in paras])
+        self.assertEqual([Action, Slug], [type(p) for p in paras])
 
     def test_transition_needs_to_be_upper_case(self):
         paras = parse([
@@ -295,7 +295,7 @@ class TransitionTests(TestCase):
             '',
             "EXT. BRICK'S POOL - DAY",
         ])
-        self.assertEquals([Action, Action, Slug], [type(p) for p in paras])
+        self.assertEqual([Action, Action, Slug], [type(p) for p in paras])
 
     def test_not_a_transition_on_trailing_whitespace(self):
         paras = parse([
@@ -305,7 +305,7 @@ class TransitionTests(TestCase):
             '',
             "EXT. BRICK'S POOL - DAY",
         ])
-        self.assertEquals([Action, Action, Slug], [type(p) for p in paras])
+        self.assertEqual([Action, Action, Slug], [type(p) for p in paras])
 
     def test_transition_does_not_have_to_be_followed_by_slug(self):
         # The "followed by slug" requirement is gone from the Jan 2012 spec
@@ -316,7 +316,7 @@ class TransitionTests(TestCase):
             '',
             'SOME GUY mowing the lawn.',
         ])
-        self.assertEquals(
+        self.assertEqual(
             [Action, Transition, Action],
             [type(p) for p in paras]
         )
@@ -329,8 +329,8 @@ class TransitionTests(TestCase):
             '',
             '.DARKNESS',
         ])
-        self.assertEquals([Action, Transition, Slug], [type(p) for p in paras])
-        self.assertEquals(plain('FADE OUT.'), paras[1].line)
+        self.assertEqual([Action, Transition, Slug], [type(p) for p in paras])
+        self.assertEqual(plain('FADE OUT.'), paras[1].line)
 
     def test_centered_text_is_not_parsed_as_transition(self):
         paras = parse([
@@ -340,7 +340,7 @@ class TransitionTests(TestCase):
             '',
             'bye!'
         ])
-        self.assertEquals([Action, Action, Action], [type(p) for p in paras])
+        self.assertEqual([Action, Action, Action], [type(p) for p in paras])
 
     def test_transition_at_end(self):
         paras = parse([
@@ -348,8 +348,8 @@ class TransitionTests(TestCase):
             '',
             '> FADE OUT.',
         ])
-        self.assertEquals([Action, Transition], [type(p) for p in paras])
-        self.assertEquals(plain('FADE OUT.'), paras[1].line)
+        self.assertEqual([Action, Transition], [type(p) for p in paras])
+        self.assertEqual(plain('FADE OUT.'), paras[1].line)
 
 
 class ActionTests(TestCase):
@@ -361,8 +361,8 @@ class ActionTests(TestCase):
             '  two spaces',
             '   three spaces ',
         ])
-        self.assertEquals([Action, Action], [type(p) for p in paras])
-        self.assertEquals(
+        self.assertEqual([Action, Action], [type(p) for p in paras])
+        self.assertEqual(
             [
                 plain(u'  two spaces'),
                 plain(u'   three spaces'),
@@ -371,7 +371,7 @@ class ActionTests(TestCase):
 
     def test_single_centered_line(self):
         paras = parse(['> center me! <'])
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
         self.assertTrue(paras[0].centered)
 
     def test_full_centered_paragraph(self):
@@ -381,9 +381,9 @@ class ActionTests(TestCase):
             '> third!< ',
         ]
         paras = parse(lines)
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
         self.assertTrue(paras[0].centered)
-        self.assertEquals([
+        self.assertEqual([
             plain('first!'),
             plain('second!'),
             plain('third!'),
@@ -395,7 +395,7 @@ class ActionTests(TestCase):
             '  > SECOND! <',
             '> THIRD! <',
         ])
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
         self.assertTrue(paras[0].centered)
 
     def test_centering_marks_in_middle_of_paragraphs_are_verbatim(self):
@@ -405,9 +405,9 @@ class ActionTests(TestCase):
             'third!',
         ]
         paras = parse(lines)
-        self.assertEquals([Action], [type(p) for p in paras])
+        self.assertEqual([Action], [type(p) for p in paras])
         self.assertFalse(paras[0].centered)
-        self.assertEquals([plain(line) for line in lines], paras[0].lines)
+        self.assertEqual([plain(line) for line in lines], paras[0].lines)
 
 
 class SynopsisTests(TestCase):
@@ -418,8 +418,8 @@ class SynopsisTests(TestCase):
             "= Set up Brick & Steel's new life."
             '',
         ])
-        self.assertEquals([Slug], [type(p) for p in paras])
-        self.assertEquals(
+        self.assertEqual([Slug], [type(p) for p in paras])
+        self.assertEqual(
             "Set up Brick & Steel's new life.",
             paras[0].synopsis
         )
@@ -430,8 +430,8 @@ class SynopsisTests(TestCase):
             '',
             '= In which we get to know our characters'
         ])
-        self.assertEquals([Section], [type(p) for p in paras])
-        self.assertEquals(
+        self.assertEqual([Section], [type(p) for p in paras])
+        self.assertEqual(
             'In which we get to know our characters',
             paras[0].synopsis
         )
@@ -442,8 +442,8 @@ class SynopsisTests(TestCase):
             '',
             '= A line that just happens to look like a synopsis'
         ])
-        self.assertEquals([Action, Action], [type(p) for p in paras])
-        self.assertEquals(
+        self.assertEqual([Action, Action], [type(p) for p in paras])
+        self.assertEqual(
             [plain('= A line that just happens to look like a synopsis')],
             paras[1].lines
         )
@@ -509,4 +509,4 @@ class PageBreakTests(TestCase):
             '',
             'So here we go'
         ])
-        self.assertEquals([PageBreak, Action], [type(p) for p in paras])
+        self.assertEqual([PageBreak, Action], [type(p) for p in paras])

--- a/tests/fountain_test.py
+++ b/tests/fountain_test.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license.php
 
-from testcompat import TestCase
+from .testcompat import TestCase
 
 from screenplain.parsers import fountain
 from screenplain.types import (

--- a/tests/richstring_test.py
+++ b/tests/richstring_test.py
@@ -26,25 +26,25 @@ class RichStringOperatorTests(TestCase):
 
     def test_repr(self):
         s = bold('Hello') + plain(' there ') + bold('folks')
-        self.assertEquals(
+        self.assertEqual(
             "(bold)('Hello') + (plain)(' there ') + (bold)('folks')",
             repr(s)
         )
 
     def test_repr_on_empty_string(self):
-        self.assertEquals('empty_string', repr(empty_string))
+        self.assertEqual('empty_string', repr(empty_string))
 
     def test_unicode(self):
         s = bold('Hello') + plain(' there ') + bold('folks')
-        self.assertEquals(
+        self.assertEqual(
             u'Hello there folks',
             str(s)
         )
 
     def test_eq(self):
-        self.assertEquals(bold('Hello'), bold('Hello'))
-        self.assertNotEquals(bold('Hello'), bold('Foo'))
-        self.assertNotEquals(plain('Hello'), bold('Hello'))
+        self.assertEqual(bold('Hello'), bold('Hello'))
+        self.assertNotEqual(bold('Hello'), bold('Foo'))
+        self.assertNotEqual(plain('Hello'), bold('Hello'))
 
     def test_ne(self):
         self.assertFalse(bold('Hello') != bold('Hello'))
@@ -54,19 +54,19 @@ class RichStringOperatorTests(TestCase):
         s1 = plain('hello')
         s2 = bold(' there')
         result = s1 + s2
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
 
 class StyleGeneratorTests(TestCase):
 
     def test_bold_function_creates_bold_richstring(self):
-        self.assertEquals(
+        self.assertEqual(
             RichString(Segment('a', (Bold,))),
             bold('a')
         )
 
     def test_adding_functions(self):
-        self.assertEquals(
+        self.assertEqual(
             RichString(Segment('a', (Bold, Italic))),
             (bold + italic)('a')
         )
@@ -75,14 +75,14 @@ class StyleGeneratorTests(TestCase):
 class RichStringTests(TestCase):
 
     def test_plain_to_html(self):
-        self.assertEquals('hello', plain('hello').to_html())
+        self.assertEqual('hello', plain('hello').to_html())
 
     def test_to_html(self):
         s = (
             bold('bold') + plain(' normal ') +
             italic('italic') + underline('wonderline')
         )
-        self.assertEquals(
+        self.assertEqual(
             '<strong>bold</strong> normal <em>italic</em><u>wonderline</u>',
             s.to_html()
         )
@@ -91,72 +91,72 @@ class RichStringTests(TestCase):
 class ParseEmphasisTests(TestCase):
 
     def test_parse_without_emphasis(self):
-        self.assertEquals(
+        self.assertEqual(
             plain('Hello'), parse_emphasis('Hello'),
             'Expected parse_emphasis to return a plain string')
 
     def test_parse_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('**Hello**'),
             bold('Hello')
         )
 
     def test_parse_pre_and_postfix_and_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('pre**Hello**post'),
             plain('pre') + bold('Hello') + plain('post')
         )
 
     def test_parse_multiple_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('x**Hello** **there**'),
             plain('x') + bold('Hello') + plain(' ') + bold('there')
         )
 
     def test_parse_adjacent_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('**123**456**'),
             bold('123') + plain('456**')
         )
 
     def test_italic(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('*Italian style*'),
             italic('Italian style')
         )
 
     def test_bold_inside_italic(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('*Swedish **style** rules*'),
             italic('Swedish ') + (bold + italic)('style') + italic(' rules')
         )
 
     def test_italic_inside_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('**Swedish *style* rules**'),
             bold('Swedish ') + (bold + italic)('style') + bold(' rules')
         )
 
     def test_italic_and_bold(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('***really strong***'),
             (bold + italic)('really strong')
         )
 
     def test_additional_star(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('*foo* bar* baz'),
             italic('foo') + plain(' bar* baz')
         )
 
     def test_underline(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('_hello_'),
             underline('hello')
         )
 
     def test_bold_inside_underline(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('_**hello**_'),
             (bold + underline)('hello')
         )
@@ -164,14 +164,14 @@ class ParseEmphasisTests(TestCase):
     def test_overlapping_underscore_and_italic(self):
         # It's unclear what result to expect in this case.
         # This is one way of interpreting it
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('_*he_llo*'),
             (italic + underline)('he') + italic('llo')
         )
 
     def test_complicated(self):
         # As reported by Stu
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis(
                 'You can _underline_ words, make them **bold** or *italic* '
                 'or even ***bold italic.***'
@@ -184,26 +184,26 @@ class ParseEmphasisTests(TestCase):
         )
 
     def test_simplified_complicated(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('*italic* or even ***bold italic.***'),
             italic('italic') + plain(' or even ') +
             (bold + italic)('bold italic.')
         )
 
     def test_two_italic_should_not_create_one_long_italic_string(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('*first* *second*'),
             italic('first') + plain(' ') + italic('second')
         )
 
     def test_two_bold_should_not_create_one_long_bold_string(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis('**first** **second**'),
             bold('first') + plain(' ') + bold('second')
         )
 
     def test_escaping_star_creates_a_literal_star(self):
-        self.assertEquals(
+        self.assertEqual(
             parse_emphasis(r'\*hello*'),
             plain('*hello*')
         )

--- a/tests/richstring_test.py
+++ b/tests/richstring_test.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license:
 # http://www.opensource.org/licenses/mit-license.php
 
-from testcompat import TestCase
+from .testcompat import TestCase
 from screenplain.richstring import (
     RichString, Segment,
     Bold, Italic,


### PR DESCRIPTION
Remove all dependencies on external test packages (particularly nose, as it will cease working very soon). Still works and the testsuite passes on 2.7.

Of course, ``pytest --doctest-modules -v`` works as well, but pytest is not required.

Also, package tests in the distribution tarball.