### PR TITLE
use sys.stdin.buffer to work around type mismatch in codecs.py

### DIFF
--- a/screenplain/main.py
+++ b/screenplain/main.py
@@ -94,7 +94,7 @@ def main(args):
     if input_file:
         input = codecs.open(input_file, 'r', 'utf-8-sig')
     else:
-        input = codecs.getreader('utf-8')(sys.stdin)
+        input = codecs.getreader('utf-8')(sys.stdin.buffer)
     screenplay = fountain.parse(input)
 
     if format == 'pdf':


### PR DESCRIPTION
This fixes an issue with reading input from `stdin`.

-----
When I run `screenplain --format=html` to take input from `stdin`, I get the following error:

```
Traceback (most recent call last):
  File ".local/bin/screenplain", line 8, in <module>
    sys.exit(cli())
  File ".local/lib/python3.9/site-packages/screenplain/main.py", line 140, in cli
    main(sys.argv[1:])
  File ".local/lib/python3.9/site-packages/screenplain/main.py", line 99, in main
    screenplay = fountain.parse(input)
  File ".local/lib/python3.9/site-packages/screenplain/parsers/fountain.py", line 219, in parse
    content = stream.read()
  File "/usr/lib/python3.9/codecs.py", line 500, in read
    data = self.bytebuffer + newdata
TypeError: can't concat str to bytes
```

This occurs with the versions installed with `pip` or from git (bc719b6).

Changing the relevant line in `codecs.py` fixes the problem.
```
data = self.bytebuffer + bytes(newdata, 'utf-8')
```
So does using `sys.stdin.buffer` in `screenplain/main.py`.