### PR TITLE
Add metadata to PDF

### DIFF
--- a/screenplain/export/pdf.py
+++ b/screenplain/export/pdf.py
@@ -4,6 +4,7 @@
 
 import sys
 import os
+import re
 
 from reportlab import platypus
 from reportlab.lib import colors, pagesizes
@@ -509,6 +510,38 @@ def get_title_page_story(screenplay, settings):
     return story
 
 
+def pdf_metadata(screenplay):
+    title_lines = screenplay.get_rich_attribute("Title")
+    author_lines = [
+        *screenplay.get_rich_attribute("Author"),
+        *screenplay.get_rich_attribute("Authors"),
+    ]
+    subject_lines = screenplay.get_rich_attribute("Subject")
+    creator_lines = screenplay.get_rich_attribute("Creator")
+    producer_lines = screenplay.get_rich_attribute("Producer")
+    keywords_lines = screenplay.get_rich_attribute("Keywords")
+
+    lang_lines = [
+        *screenplay.get_rich_attribute("Lang"),
+        *screenplay.get_rich_attribute("Language"),
+    ]
+
+    return {
+        "title":   ' '.join([str(line) for line in title_lines]) or None,
+        "subject": ' '.join([str(line) for line in subject_lines]) or None,
+        "author": ', '.join([str(line) for line in author_lines]) or None,
+        "creator": ' '.join([str(line) for line in creator_lines]) or None,
+        "producer": ' '.join([str(line) for line in producer_lines]) or None,
+        "keywords": [
+            word.strip()
+            for line in keywords_lines
+            for word in re.split('[,;/]', str(line))
+            if word.strip()
+        ],
+        "lang":    ' '.join([str(line) for line in lang_lines]) or None,
+    }
+
+
 def to_pdf(
     screenplay, output_filename,
     template_constructor=DocTemplate,
@@ -540,10 +573,12 @@ def to_pdf(
             # Ignore unknown types
             pass
 
+    meta = pdf_metadata(screenplay)
     doc = template_constructor(
         output_filename,
         pagesize=(settings.page_width, settings.page_height),
         settings=settings,
-        has_title_page=has_title_page
+        has_title_page=has_title_page,
+        **meta,
     )
     doc.build(story)

--- a/screenplain/export/pdf.py
+++ b/screenplain/export/pdf.py
@@ -517,8 +517,6 @@ def pdf_metadata(screenplay):
         *screenplay.get_rich_attribute("Authors"),
     ]
     subject_lines = screenplay.get_rich_attribute("Subject")
-    creator_lines = screenplay.get_rich_attribute("Creator")
-    producer_lines = screenplay.get_rich_attribute("Producer")
     keywords_lines = screenplay.get_rich_attribute("Keywords")
 
     lang_lines = [
@@ -530,8 +528,6 @@ def pdf_metadata(screenplay):
         "title":   ' '.join([str(line) for line in title_lines]) or None,
         "subject": ' '.join([str(line) for line in subject_lines]) or None,
         "author": ', '.join([str(line) for line in author_lines]) or None,
-        "creator": ' '.join([str(line) for line in creator_lines]) or None,
-        "producer": ' '.join([str(line) for line in producer_lines]) or None,
         "keywords": [
             word.strip()
             for line in keywords_lines


### PR DESCRIPTION
This PR writes common PDF metadata as specified in the title page information:

- Title
- Subject
- Author
- Keywords
- Lang

I wanted to just write everything in the title page as custom metadata, but that would require some light hacking of reportlab